### PR TITLE
feat: updated for `pieces` v3 (#260)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 	"dependencies": {
 		"@sapphire/discord-utilities": "^2.1.5",
 		"@sapphire/discord.js-utilities": "next",
-		"@sapphire/pieces": "^2.2.0",
+		"@sapphire/pieces": "^3.0.0",
 		"@sapphire/ratelimits": "^2.0.1",
 		"@sapphire/utilities": "^2.0.1",
 		"lexure": "^0.17.0",

--- a/src/errorListeners/CoreCommandError.ts
+++ b/src/errorListeners/CoreCommandError.ts
@@ -8,7 +8,7 @@ export class CoreEvent extends Listener<typeof Events.CommandError> {
 	}
 
 	public run(error: Error, context: CommandErrorPayload) {
-		const { name, path } = context.piece;
-		this.container.logger.error(`Encountered error on command "${name}" at path "${path}"`, error);
+		const { name, location } = context.piece;
+		this.container.logger.error(`Encountered error on command "${name}" at path "${location.full}"`, error);
 	}
 }

--- a/src/errorListeners/CoreEventError.ts
+++ b/src/errorListeners/CoreEventError.ts
@@ -8,7 +8,7 @@ export class CoreEvent extends Listener<typeof Events.ListenerError> {
 	}
 
 	public run(error: Error, context: ListenerErrorPayload) {
-		const { name, event, path } = context.piece;
-		this.container.logger.error(`Encountered error on event listener "${name}" for event "${event}" at path "${path}"`, error);
+		const { name, event, location } = context.piece;
+		this.container.logger.error(`Encountered error on event listener "${name}" for event "${event}" at path "${location.full}"`, error);
 	}
 }

--- a/src/lib/structures/CommandStore.ts
+++ b/src/lib/structures/CommandStore.ts
@@ -9,4 +9,13 @@ export class CommandStore extends AliasStore<Command> {
 	public constructor() {
 		super(Command as any, { name: 'commands' });
 	}
+
+	/**
+	 * Get all the command categories.
+	 */
+	public get categories(): string[] {
+		const categories = new Set(this.map((command) => command.category));
+		categories.delete(null);
+		return [...categories] as string[];
+	}
 }

--- a/src/lib/structures/Listener.ts
+++ b/src/lib/structures/Listener.ts
@@ -1,4 +1,4 @@
-import { Piece, PieceContext, PieceOptions } from '@sapphire/pieces';
+import { Piece, PieceContext, PieceJSON, PieceOptions } from '@sapphire/pieces';
 import type { Client, ClientEvents } from 'discord.js';
 import type { EventEmitter } from 'events';
 import { Events } from '../types/Events';
@@ -109,7 +109,7 @@ export abstract class Listener<E extends keyof ClientEvents | symbol = ''> exten
 		return super.onUnload();
 	}
 
-	public toJSON(): Record<PropertyKey, unknown> {
+	public toJSON(): ListenerJSON {
 		return {
 			...super.toJSON(),
 			once: this.once,
@@ -135,4 +135,9 @@ export interface ListenerOptions extends PieceOptions {
 	readonly emitter?: keyof Client | EventEmitter;
 	readonly event?: string;
 	readonly once?: boolean;
+}
+
+export interface ListenerJSON extends PieceJSON {
+	event: string;
+	once: boolean;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -805,10 +805,10 @@
   dependencies:
     cross-fetch "^3.1.4"
 
-"@sapphire/pieces@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@sapphire/pieces/-/pieces-2.2.0.tgz#9e45fe1462996d35d513dbafeab713aa5eb4adae"
-  integrity sha512-VhUMUshM7IvKQ/JXJBUUZYO28fHQQ4+2mxHf2q+Rrm6ZOJAOXrYuplc/JBJ7sHb+Icr8WFhUazlarjKbEjErZw==
+"@sapphire/pieces@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sapphire/pieces/-/pieces-3.0.0.tgz#968878dee0c680d00dc29202a4fc15f1daea2b5d"
+  integrity sha512-Up/ajwm88jLHmG/AKmiEAyBcXlBEV2p96KXYIjoJVX2/bCr+zK+lDWDPE2cg5dJPfU6CABEdMqV5h/wdQxgf9A==
   dependencies:
     "@discordjs/collection" "^0.2.1"
     "@sapphire/utilities" "^2.0.1"


### PR DESCRIPTION
feat(Command): make `fullCategory` not nullable
refactor(Command): remove category detection workaround
refactor(Command): improved logic for `category` getter
refactor(Command): improved logic for `subCategory` getter
refactor(Command): improved logic for `parentCategory` getter
refactor(Command): strict type `toJSON()`
refactor(Listener): strict type `toJSON()`

BREAKING CHANGE: Updated `@sapphire/pieces` to `3.0.0`
BREAKING CHANGE: Removed `Command#categories`, use `CommandStore#categories` instead